### PR TITLE
add option to restrict chapter range

### DIFF
--- a/mloader/__main__.py
+++ b/mloader/__main__.py
@@ -145,6 +145,18 @@ Examples:
     expose_value=False,
     callback=validate_ids,
 )
+@click.option(
+    "--begin",
+    "-b",
+    type=click.INT,
+    help="Minimal chapter to try to download (only works with single id).",
+)
+@click.option(
+    "--end",
+    "-e",
+    type=click.INT,
+    help="Minimal chapter to try to download (only works with single id).",
+)
 @click.argument("urls", nargs=-1, callback=validate_urls, expose_value=False)
 @click.pass_context
 def main(
@@ -155,6 +167,8 @@ def main(
     split: bool,
     chapters: Optional[Set[int]] = None,
     titles: Optional[Set[int]] = None,
+    begin: int = None,
+    end: int = None,
 ):
     click.echo(click.style(about.__doc__, fg="blue"))
     if not any((chapters, titles)):
@@ -164,7 +178,7 @@ def main(
 
     loader = MangaLoader(RawExporter if raw else CBZExporter, quality, split)
     try:
-        loader.download(title_ids=titles, chapter_ids=chapters, dst=out_dir)
+        loader.download(title_ids=titles, chapter_ids=chapters, dst=out_dir, begin=begin, end=end)
     except Exception:
         log.exception("Failed to download manga")
     log.info("SUCCESS")

--- a/mloader/loader.py
+++ b/mloader/loader.py
@@ -106,7 +106,7 @@ class MangaLoader:
 
         return mangas
 
-    def _download(self, manga_list: MangaList, dst: str):
+    def _download(self, manga_list: MangaList, dst: str, begin: int, end : int):
         manga_num = len(manga_list)
         for title_index, (title_id, chapters) in enumerate(
             manga_list.items(), 1
@@ -130,6 +130,11 @@ class MangaLoader:
                     f"    {chapter_index}/{chapter_num}) "
                     f"Chapter {chapter_name}: {chapter.sub_title}"
                 )
+                if (begin and begin > int(chapter_name[1:])) or (end and end < int(chapter_name[1:])):
+                    log.info(
+                        f"                        SKIPPED"
+                    )
+                    continue
                 exporter = self.exporter_cls(dst, title, chapter, next_chapter)
                 pages = [
                     p.manga_page for p in viewer.pages if p.manga_page.image_url
@@ -156,5 +161,7 @@ class MangaLoader:
         title_ids: Optional[Collection[int]] = None,
         chapter_ids: Optional[Collection[int]] = None,
         dst: str = ".",
+        begin: int = None,
+        end: int = None,
     ):
-        self._download(self._normalize_ids(title_ids, chapter_ids), dst)
+        self._download(self._normalize_ids(title_ids, chapter_ids), dst, begin, end)


### PR DESCRIPTION
A slighlty more general approach to solve https://github.com/hurlenko/mloader/issues/12 .
This makes it possible to only download chapters within begin <= chapter <= end.