### PR TITLE
Fixing multipart chapter names

### DIFF
--- a/mloader/exporter.py
+++ b/mloader/exporter.py
@@ -80,7 +80,20 @@ class ExporterBase(metaclass=ABCMeta):
                 prefix = "c" if chapter_num < 1000 else "d"
 
         if chapter_num is None:
-            chapter_num = escape_path(chapter_name)
+            if '#' in chapter_name:
+                chapter_name = chapter_name.replace("#","")
+                if '-' in chapter_name:
+                    special_char = '-'
+                if ',' in chapter_name:
+                    special_char = ','
+                if '.' in chapter_name:
+                    special_char = '.'
+                # to simplify things suffix was not used
+                chapter_name_num = chapter_name.split(special_char)[0]
+                chapter_num = chapter_name.replace(special_char,"x")
+                prefix = "c" if len(chapter_name_num) < 4 else "d"
+            else:
+                chapter_num = escape_path(chapter_name)
 
         components.append(f"{prefix}{chapter_num:0>3}{suffix}")
         components.append("(web)")

--- a/mloader/exporter.py
+++ b/mloader/exporter.py
@@ -66,37 +66,48 @@ class ExporterBase(metaclass=ABCMeta):
         components.append("-")
         suffix = ""
         prefix = ""
+        extra = ""
         if self.is_oneshot:
             chapter_num = 0
         elif self.is_extra and next_chapter_name:
             suffix = "x1"
             chapter_num = chapter_name_to_int(next_chapter_name)
+            extra = " [Extra]"
             if chapter_num is not None:
                 chapter_num -= 1
                 prefix = "c" if chapter_num < 1000 else "d"
+            # fallback if the chapter we obtain number from is also an extra
+            else:
+                prefix = "c"
+                chapter_num = "0"
         else:
             chapter_num = chapter_name_to_int(chapter_name)
             if chapter_num is not None:
                 prefix = "c" if chapter_num < 1000 else "d"
 
         if chapter_num is None:
-            if '#' in chapter_name:
+            # part 2 that are called *.5 are unfixable
+            if "#" in chapter_name:
                 chapter_name = chapter_name.replace("#","")
-                if '-' in chapter_name:
-                    special_char = '-'
-                if ',' in chapter_name:
-                    special_char = ','
-                if '.' in chapter_name:
-                    special_char = '.'
-                # to simplify things suffix was not used
-                chapter_name_num = chapter_name.split(special_char)[0]
-                chapter_num = chapter_name.replace(special_char,"x")
-                prefix = "c" if len(chapter_name_num) < 4 else "d"
+                if "-" in chapter_name:
+                    special_char = "-"
+                if "," in chapter_name:
+                    special_char = ","
+                if "." in chapter_name:
+                    special_char = "."
+                chapter_num = chapter_name.split(special_char)[0]
+                suffix = chapter_name.split(special_char)[1]
+                # removing leading zeros because of there being a chapter called '#000,001'
+                suffix = suffix.lstrip("0")
+                suffix = "x" + suffix if len(suffix) < 2 else "x" + suffix
+                prefix = "c" if len(chapter_num) < 4 else "d"
+                # could be more detailed if chosen to incl chapter subtitle in function parameters
+                extra = " [Part]"
             else:
                 chapter_num = escape_path(chapter_name)
 
         components.append(f"{prefix}{chapter_num:0>3}{suffix}")
-        components.append("(web)")
+        components.append(f"(web){extra}")
         return " ".join(components)
 
     def _format_chapter_suffix(self) -> str:


### PR DESCRIPTION
this is more or less a draft. I don't really do stuff with python but be a start to fix naming for multipart chapters and if extra chapters follow extra chapters.
if extra chapters follow extras the chapter before would end up getting called `0exx` but now we are stuck with `c000x1` ideally a better solution could be found but now it adheres to the standard.
