### PR TITLE
fix cases where there are no images on the web site, error 404

### DIFF
--- a/mloader/loader.py
+++ b/mloader/loader.py
@@ -141,6 +141,8 @@ class MangaLoader:
             chapter_num = len(chapters)
             for chapter_index, chapter_id in enumerate(sorted(chapters), 1):
                 viewer = self._load_pages(chapter_id)
+                if len(viewer.pages) == 0:
+                    continue
                 chapter = viewer.pages[-1].last_page.current_chapter
                 next_chapter = viewer.pages[-1].last_page.next_chapter
                 next_chapter = (


### PR DESCRIPTION
fix cases where there are no images on the web site, error 404

for example, Terra Formars last chapter gives a 404 error on the web site:

`python.exe -m mloader -l -r --chapter-subdir -t 100025`

```
01.06.2023 12:49:16 |   INFO   |   loader.py    138  | 29/29) Manga: Terra Formars
01.06.2023 12:49:16 |   INFO   |   loader.py    139  |     Author: Ken-ichi Tachibana / Yu Sasuga
01.06.2023 12:49:17 |  ERROR   |  __main__.py   223  | Failed to download manga
Traceback (most recent call last):
  File "C:\Users\rodi_\workspace\mloader\mloader\__main__.py", line 215, in main
    loader.download(
  File "C:\Users\rodi_\workspace\mloader\mloader\loader.py", line 189, in download
    self._download(manga_list)
  File "C:\Users\rodi_\workspace\mloader\mloader\loader.py", line 144, in _download
    chapter = viewer.pages[-1].last_page.current_chapter
              ~~~~~~~~~~~~^^^^
  File "C:\Users\rodi_\workspace\mloader\venv\Lib\site-packages\google\protobuf\internal\containers.py", line 93, in __getitem__
    return self._values[key]
           ~~~~~~~~~~~~^^^^^
```