### PR TITLE
Add Nix flake

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1685566663,
+        "narHash": "sha256-btHN1czJ6rzteeCuE/PNrdssqYD2nIA4w48miQAFloM=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "4ecab3273592f27479a583fb6d975d4aba3486fe",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "23.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,61 @@
+{
+  description = "intake feed sources";
+
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/23.05";
+
+  outputs = { self, nixpkgs }:
+  let
+    # Systems to build packages for.
+    supportedSystems = [
+      "x86_64-linux"
+      "aarch64-linux"
+    ];
+
+    # Helper to create an attrset by applying a function to each system.
+    forAllSystems = func: nixpkgs.lib.genAttrs supportedSystems func;
+  in {
+    # Build the package for each system by applying the default overlay to
+    # the system and using the package it adds.
+    packages = forAllSystems (system:
+    {
+      default = (import nixpkgs {
+        inherit system;
+        overlays = [ self.overlays.default ];
+      }).mloader;
+    });
+
+    # Provide a default app that runs mloader.
+    apps = forAllSystems (system: {
+      default = {
+        type = "app";
+        program = "${self.packages.${system}.default}/bin/mloader";
+      };
+    });
+
+    # Provide a default overlay that adds mloader to the package set.
+    overlays.default = final: prev: let
+      # with protobuf 3.21 the python package version is 4.21, so the last
+      # version that satisfies the ~=3.6 constraint is 3.20
+      py_protobuf_3_20 = final.python3Packages.protobuf.override {
+        protobuf = final.protobuf3_20;
+      };
+    in {
+      mloader = final.python3Packages.buildPythonPackage {
+        name = "mloader";
+        src = builtins.path { name = "mloader"; path = ./.; };
+        format = "setuptools";
+        propagatedBuildInputs = with final.python3Packages; [
+          click
+          py_protobuf_3_20
+          requests
+        ];
+      };
+    };
+
+    # Provide a nixos module that applies the default overlay.
+    nixosModules.default = {
+      nixpkgs.overlays = [ self.overlays.default ];
+    };
+  };
+}
+


### PR DESCRIPTION
Nix is a reproducible and declarative build system. All inputs and build steps are declared in Nix configuration so builds can be run in an isolated environment that is reproducible across machines.

This PR adds a `flake.nix` file, which allows it to be used with the popular flakes feature of Nix. With a flakes-enabled Nix, anyone can run
```
nix run github:Jaculabilis/mloader/nix-flake
```
and `mloader` will be built and run locally. Running `nix develop` in the repository root launches a shell with the same packages present in the build environment and an editable install of the local package.